### PR TITLE
Fix syntax highlight and add file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ This action uses [Size Limit](https://github.com/ai/size-limit) (performance bud
   }
 ]
 ```
-4. Add the following action inside `.github/workflows`
-```
+4. Add the following action inside `.github/workflows/size-limit.yml`
+```yaml
 name: "size"
 on:
   pull_request:


### PR DESCRIPTION
Everyone like syntax highlighting.

I added the exact name because users do not like to think. We can think that people who will want a different name will understand that they can change it.