### PR TITLE
Fix crashes due to changes in size-limit sections

### DIFF
--- a/src/SizeLimit.spec.ts
+++ b/src/SizeLimit.spec.ts
@@ -60,7 +60,7 @@ describe("SizeLimit", () => {
         running: 0.20210999999999999,
         loading: 2.5658984375,
         total: 2.7680084375000003
-      }
+      },
     };
 
     expect(limit.formatResults(base, current)).toEqual([
@@ -96,6 +96,66 @@ describe("SizeLimit", () => {
         "dist/index.js",
         "98.53 KB (-9.92% 🔽)"
       ]
+    ]);
+  });
+
+  test("should format size-limit with new section", () => {
+    const limit = new SizeLimit();
+    const base = {
+      "dist/index.js": {
+        name: "dist/index.js",
+        size: 110894
+      }
+    };
+    const current = {
+      "dist/index.js": {
+        name: "dist/index.js",
+        size: 100894
+      },
+      "dist/new.js": {
+        name: "dist/new.js",
+        size: 100894
+      }
+    };
+
+    expect(limit.formatResults(base, current)).toEqual([
+      SizeLimit.SIZE_RESULTS_HEADER,
+      [
+        "dist/index.js",
+        "98.53 KB (-9.92% 🔽)"
+      ],
+      [
+        "dist/new.js",
+        "98.53 KB (+100% 🔺)"
+      ],
+    ]);
+  });
+
+  test("should format size-limit with deleted section", () => {
+    const limit = new SizeLimit();
+    const base = {
+      "dist/index.js": {
+        name: "dist/index.js",
+        size: 110894
+      }
+    };
+    const current = {
+      "dist/new.js": {
+        name: "dist/new.js",
+        size: 100894
+      }
+    };
+
+    expect(limit.formatResults(base, current)).toEqual([
+      SizeLimit.SIZE_RESULTS_HEADER,
+      [
+        "dist/index.js",
+        "0 B (-100%)"
+      ],
+      [
+        "dist/new.js",
+        "98.53 KB (+100% 🔺)"
+      ],
     ]);
   });
 });

--- a/src/SizeLimit.ts
+++ b/src/SizeLimit.ts
@@ -9,6 +9,14 @@ interface IResult {
   total?: number;
 }
 
+const EmptyResult = {
+  name: "-",
+  size: 0,
+  running: 0,
+  loading: 0,
+  total: 0
+};
+
 class SizeLimit {
   static SIZE_RESULTS_HEADER = ["Path", "Size"];
 
@@ -130,16 +138,19 @@ class SizeLimit {
   ): Array<Array<string>> {
     const names = [...new Set([...Object.keys(base), ...Object.keys(current)])];
     const isSize = names.some(
-      (name: string) => current[name].total === undefined
+      (name: string) => current[name] && current[name].total === undefined
     );
     const header = isSize
       ? SizeLimit.SIZE_RESULTS_HEADER
       : SizeLimit.TIME_RESULTS_HEADER;
     const fields = names.map((name: string) => {
+      const baseResult = base[name] || EmptyResult;
+      const currentResult = current[name] || EmptyResult;
+
       if (isSize) {
-        return this.formatSizeResult(name, base[name], current[name]);
+        return this.formatSizeResult(name, baseResult, currentResult);
       }
-      return this.formatTimeResult(name, base[name], current[name]);
+      return this.formatTimeResult(name, baseResult, currentResult);
     });
 
     return [header, ...fields];


### PR DESCRIPTION
now action falls with `Cannot read property 'size' of undefined` if `size-limit` config section added or deleted:
- https://github.com/babajka/babajka-frontend/pull/103/files#diff-445c4a6aec537e749519a382896d04be
- https://github.com/babajka/babajka-frontend/pull/103/checks?check_run_id=659543495#step:3:1736