### PR TITLE
Use checks instead of pull request reviews, post and update single comment instead of posting many reviews

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2039,9 +2039,8 @@ function run() {
                 console.log("Error parsing size-limit output. The output should be a json.");
                 throw error;
             }
-            const failed = status > 0; // ? "REQUEST_CHANGES" : "COMMENT";
-            if (failed) {
-                core_1.setFailed("Failed");
+            if (status > 0) {
+                core_1.setFailed("Size limit has been exceeded.");
             }
             const body = [
                 SIZE_LIMIT_HEADING,
@@ -2049,9 +2048,9 @@ function run() {
             ].join("\r\n");
             const { data: commentList } = yield octokit.issues.listComments(Object.assign(Object.assign({}, repo), { issue_number: pr.number }));
             const sizeLimitComment = commentList.find(comment => comment.body.startsWith(SIZE_LIMIT_HEADING));
-            if (sizeLimitComment == undefined) {
+            if (!sizeLimitComment) {
                 try {
-                    octokit.issues.createComment(Object.assign(Object.assign({}, repo), { 
+                    yield octokit.issues.createComment(Object.assign(Object.assign({}, repo), { 
                         // eslint-disable-next-line camelcase
                         issue_number: pr.number, body }));
                 }
@@ -2061,7 +2060,7 @@ function run() {
             }
             else {
                 try {
-                    octokit.issues.updateComment(Object.assign(Object.assign({}, repo), { 
+                    yield octokit.issues.updateComment(Object.assign(Object.assign({}, repo), { 
                         // eslint-disable-next-line camelcase
                         comment_id: sizeLimitComment.id, body }));
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -2012,6 +2012,7 @@ const markdown_table_1 = __importDefault(__webpack_require__(366));
 const Term_1 = __importDefault(__webpack_require__(733));
 const SizeLimit_1 = __importDefault(__webpack_require__(617));
 const SIZE_LIMIT_URL = "https://github.com/ai/size-limit";
+const SIZE_LIMIT_HEADING = `## [size-limit](${SIZE_LIMIT_URL}) report`;
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -2038,19 +2039,35 @@ function run() {
                 console.log("Error parsing size-limit output. The output should be a json.");
                 throw error;
             }
-            const event = status > 0 ? "REQUEST_CHANGES" : "COMMENT";
+            const failed = status > 0; // ? "REQUEST_CHANGES" : "COMMENT";
+            if (failed) {
+                core_1.setFailed("Failed");
+            }
             const body = [
-                `## [size-limit](${SIZE_LIMIT_URL}) report`,
+                SIZE_LIMIT_HEADING,
                 markdown_table_1.default(limit.formatResults(base, current))
             ].join("\r\n");
-            try {
-                octokit.pulls.createReview(Object.assign(Object.assign({}, repo), { 
-                    // eslint-disable-next-line camelcase
-                    pull_number: pr.number, event,
-                    body }));
+            const { data: commentList } = yield octokit.issues.listComments(Object.assign(Object.assign({}, repo), { issue_number: pr.number }));
+            const sizeLimitComment = commentList.find(comment => comment.body.startsWith(SIZE_LIMIT_HEADING));
+            if (sizeLimitComment == undefined) {
+                try {
+                    octokit.issues.createComment(Object.assign(Object.assign({}, repo), { 
+                        // eslint-disable-next-line camelcase
+                        issue_number: pr.number, body }));
+                }
+                catch (error) {
+                    console.log("Error creating comment. This can happen for PR's originating from a fork without write permissions.");
+                }
             }
-            catch (error) {
-                console.log("Error creating PR review. This can happen for PR's originating from a fork without write permissions.");
+            else {
+                try {
+                    octokit.issues.updateComment(Object.assign(Object.assign({}, repo), { 
+                        // eslint-disable-next-line camelcase
+                        comment_id: sizeLimitComment.id, body }));
+                }
+                catch (error) {
+                    console.log("Error updating comment. This can happen for PR's originating from a fork without write permissions.");
+                }
             }
         }
         catch (error) {
@@ -2650,7 +2667,7 @@ exports.getUserAgent = getUserAgent;
 /***/ 215:
 /***/ (function(module) {
 
-module.exports = {"_args":[["@octokit/rest@16.43.1","/Users/andres.alvarez/Projects/size-limit-action"]],"_from":"@octokit/rest@16.43.1","_id":"@octokit/rest@16.43.1","_inBundle":false,"_integrity":"sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==","_location":"/@octokit/rest","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"@octokit/rest@16.43.1","name":"@octokit/rest","escapedName":"@octokit%2frest","scope":"@octokit","rawSpec":"16.43.1","saveSpec":null,"fetchSpec":"16.43.1"},"_requiredBy":["/@actions/github"],"_resolved":"https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz","_spec":"16.43.1","_where":"/Users/andres.alvarez/Projects/size-limit-action","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/rest.js/issues"},"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}],"contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"dependencies":{"@octokit/auth-token":"^2.4.0","@octokit/plugin-paginate-rest":"^1.1.1","@octokit/plugin-request-log":"^1.0.0","@octokit/plugin-rest-endpoint-methods":"2.4.0","@octokit/request":"^5.2.0","@octokit/request-error":"^1.0.2","atob-lite":"^2.0.0","before-after-hook":"^2.0.0","btoa-lite":"^1.0.0","deprecation":"^2.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","once":"^1.4.0","universal-user-agent":"^4.0.0"},"description":"GitHub REST API client for Node.js","devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/auth":"^1.1.1","@octokit/fixtures-server":"^5.0.6","@octokit/graphql":"^4.2.0","@types/node":"^13.1.0","bundlesize":"^0.18.0","chai":"^4.1.2","compression-webpack-plugin":"^3.1.0","cypress":"^3.0.0","glob":"^7.1.2","http-proxy-agent":"^4.0.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","lolex":"^5.1.2","mkdirp":"^1.0.0","mocha":"^7.0.1","mustache":"^4.0.0","nock":"^11.3.3","npm-run-all":"^4.1.2","nyc":"^15.0.0","prettier":"^1.14.2","proxy":"^1.0.0","semantic-release":"^17.0.0","sinon":"^8.0.0","sinon-chai":"^3.0.0","sort-keys":"^4.0.0","string-to-arraybuffer":"^1.0.0","string-to-jsdoc-comment":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"files":["index.js","index.d.ts","lib","plugins"],"homepage":"https://github.com/octokit/rest.js#readme","keywords":["octokit","github","rest","api-client"],"license":"MIT","name":"@octokit/rest","nyc":{"ignore":["test"]},"publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/rest.js.git"},"scripts":{"build":"npm-run-all build:*","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","build:ts":"npm run -s update-endpoints:typescript","coverage":"nyc report --reporter=html && open coverage/index.html","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","lint":"prettier --check '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","lint:fix":"prettier --write '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","prebuild:browser":"mkdirp dist/","pretest":"npm run -s lint","prevalidate:ts":"npm run -s build:ts","start-fixtures-server":"octokit-fixtures-server","test":"nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"","test:browser":"cypress run --browser chrome","update-endpoints":"npm-run-all update-endpoints:*","update-endpoints:fetch-json":"node scripts/update-endpoints/fetch-json","update-endpoints:typescript":"node scripts/update-endpoints/typescript","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts"},"types":"index.d.ts","version":"16.43.1"};
+module.exports = {"_args":[["@octokit/rest@16.43.1","/home/vince/Documents/mathNEWS/size-limit-action"]],"_from":"@octokit/rest@16.43.1","_id":"@octokit/rest@16.43.1","_inBundle":false,"_integrity":"sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==","_location":"/@octokit/rest","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"@octokit/rest@16.43.1","name":"@octokit/rest","escapedName":"@octokit%2frest","scope":"@octokit","rawSpec":"16.43.1","saveSpec":null,"fetchSpec":"16.43.1"},"_requiredBy":["/@actions/github"],"_resolved":"https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz","_spec":"16.43.1","_where":"/home/vince/Documents/mathNEWS/size-limit-action","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/rest.js/issues"},"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}],"contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"dependencies":{"@octokit/auth-token":"^2.4.0","@octokit/plugin-paginate-rest":"^1.1.1","@octokit/plugin-request-log":"^1.0.0","@octokit/plugin-rest-endpoint-methods":"2.4.0","@octokit/request":"^5.2.0","@octokit/request-error":"^1.0.2","atob-lite":"^2.0.0","before-after-hook":"^2.0.0","btoa-lite":"^1.0.0","deprecation":"^2.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","once":"^1.4.0","universal-user-agent":"^4.0.0"},"description":"GitHub REST API client for Node.js","devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/auth":"^1.1.1","@octokit/fixtures-server":"^5.0.6","@octokit/graphql":"^4.2.0","@types/node":"^13.1.0","bundlesize":"^0.18.0","chai":"^4.1.2","compression-webpack-plugin":"^3.1.0","cypress":"^3.0.0","glob":"^7.1.2","http-proxy-agent":"^4.0.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","lolex":"^5.1.2","mkdirp":"^1.0.0","mocha":"^7.0.1","mustache":"^4.0.0","nock":"^11.3.3","npm-run-all":"^4.1.2","nyc":"^15.0.0","prettier":"^1.14.2","proxy":"^1.0.0","semantic-release":"^17.0.0","sinon":"^8.0.0","sinon-chai":"^3.0.0","sort-keys":"^4.0.0","string-to-arraybuffer":"^1.0.0","string-to-jsdoc-comment":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"files":["index.js","index.d.ts","lib","plugins"],"homepage":"https://github.com/octokit/rest.js#readme","keywords":["octokit","github","rest","api-client"],"license":"MIT","name":"@octokit/rest","nyc":{"ignore":["test"]},"publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/rest.js.git"},"scripts":{"build":"npm-run-all build:*","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","build:ts":"npm run -s update-endpoints:typescript","coverage":"nyc report --reporter=html && open coverage/index.html","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","lint":"prettier --check '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","lint:fix":"prettier --write '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","prebuild:browser":"mkdirp dist/","pretest":"npm run -s lint","prevalidate:ts":"npm run -s build:ts","start-fixtures-server":"octokit-fixtures-server","test":"nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"","test:browser":"cypress run --browser chrome","update-endpoints":"npm-run-all update-endpoints:*","update-endpoints:fetch-json":"node scripts/update-endpoints/fetch-json","update-endpoints:typescript":"node scripts/update-endpoints/typescript","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts"},"types":"index.d.ts","version":"16.43.1"};
 
 /***/ }),
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2013,6 +2013,18 @@ const Term_1 = __importDefault(__webpack_require__(733));
 const SizeLimit_1 = __importDefault(__webpack_require__(617));
 const SIZE_LIMIT_URL = "https://github.com/ai/size-limit";
 const SIZE_LIMIT_HEADING = `## [size-limit](${SIZE_LIMIT_URL}) report`;
+function fetchPreviousComment(octokit, repo, pr) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const commentList = yield octokit.paginate(
+        // TODO: replace with octokit.issues.listComments when upgraded to v17
+        //octokit.issues.listComments, {
+        "GET /repos/:owner/:repo/issues/:issue_number/comments", Object.assign(Object.assign({}, repo), { 
+            // eslint-disable-next-line camelcase
+            issue_number: pr.number }));
+        const sizeLimitComment = commentList.find((comment) => comment.body.startsWith(SIZE_LIMIT_HEADING));
+        return !sizeLimitComment ? null : sizeLimitComment;
+    });
+}
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -2046,8 +2058,7 @@ function run() {
                 SIZE_LIMIT_HEADING,
                 markdown_table_1.default(limit.formatResults(base, current))
             ].join("\r\n");
-            const { data: commentList } = yield octokit.issues.listComments(Object.assign(Object.assign({}, repo), { issue_number: pr.number }));
-            const sizeLimitComment = commentList.find(comment => comment.body.startsWith(SIZE_LIMIT_HEADING));
+            const sizeLimitComment = yield fetchPreviousComment(octokit, repo, pr);
             if (!sizeLimitComment) {
                 try {
                     yield octokit.issues.createComment(Object.assign(Object.assign({}, repo), { 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "size-limit-action",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,8 @@
 import { getInput, setFailed } from "@actions/core";
 import { context, GitHub } from "@actions/github";
+
+import { Octokit } from "@octokit/rest";
+
 // @ts-ignore
 import table from "markdown-table";
 import Term from "./Term";
@@ -7,6 +10,30 @@ import SizeLimit from "./SizeLimit";
 
 const SIZE_LIMIT_URL = "https://github.com/ai/size-limit";
 const SIZE_LIMIT_HEADING = `## [size-limit](${SIZE_LIMIT_URL}) report`;
+
+async function fetchPreviousComment(
+  octokit: GitHub,
+  repo: { owner: string; repo: string },
+  pr: { number: number }
+) {
+
+  const commentList: Octokit.IssuesListCommentsResponse = await octokit.paginate(
+    // TODO: replace with octokit.issues.listComments when upgraded to v17
+    //octokit.issues.listComments, {
+    "GET /repos/:owner/:repo/issues/:issue_number/comments",
+    {
+      ...repo,
+      // eslint-disable-next-line camelcase
+      issue_number: pr.number
+    });
+
+
+  const sizeLimitComment = commentList.find(
+    (comment: Octokit.IssuesListCommentsResponseItem) =>
+    comment.body.startsWith(SIZE_LIMIT_HEADING)
+  );
+  return !sizeLimitComment ? null : sizeLimitComment;
+}
 
 async function run() {
   try {
@@ -58,14 +85,7 @@ async function run() {
       table(limit.formatResults(base, current))
     ].join("\r\n");
 
-    const { data: commentList } = await octokit.issues.listComments({
-      ...repo,
-      issue_number: pr.number
-    });
-
-    const sizeLimitComment = commentList.find(comment =>
-      comment.body.startsWith(SIZE_LIMIT_HEADING)
-    );
+    const sizeLimitComment = await fetchPreviousComment(octokit, repo, pr);
 
     if (!sizeLimitComment) {
       try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,9 +50,8 @@ async function run() {
       throw error;
     }
 
-    const failed = status > 0;// ? "REQUEST_CHANGES" : "COMMENT";
-    if (failed) {
-      setFailed("Failed");
+    if (status > 0) {
+      setFailed("Size limit has been exceeded.");
     }
     const body = [
       SIZE_LIMIT_HEADING,
@@ -68,9 +67,9 @@ async function run() {
       comment.body.startsWith(SIZE_LIMIT_HEADING)
     );
 
-    if (sizeLimitComment == undefined) {
+    if (!sizeLimitComment) {
       try {
-        octokit.issues.createComment({
+        await octokit.issues.createComment({
           ...repo,
           // eslint-disable-next-line camelcase
           issue_number: pr.number,
@@ -83,7 +82,7 @@ async function run() {
       }
     } else {
       try {
-        octokit.issues.updateComment({
+        await octokit.issues.updateComment({
           ...repo,
           // eslint-disable-next-line camelcase
           comment_id: sizeLimitComment.id,


### PR DESCRIPTION
This fixes #24.

Using checks and posting a single updating comment is also the behaviour used by [codecov](https://github.com/apps/codecov).

#18/#20 is similar, and I adapted some of the changes from there.

However, I think this solution is better because it solves almost all of the issues @dcwither [listed](https://github.com/andresz1/size-limit-action/pull/18#issuecomment-632371376).

In particular. this solution keeps the history, since you can go back and see the edit history of the comment (although I think updating the PR review does that as well).

I'll note I don't have too much experience with TypeScript, so I apologize for any errors. This is also my first time working on a custom action.