### PR TITLE
Add support for size file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ with:
   skip_step: install
 ```
 
+For cases where you need to do additional authentication or have a non standard configuration you can provide size-limit report files directly. Specifying `base_size_path` and `head_size_path` will use the file directly for comparison and skip all the other steps.
+
+```yaml
+with:
+  github_token: ${{ secrets.GITHUB_TOKEN }}
+  base_size_path: ./base/client/size.json
+  head_size_path: ./head/client/size.json
+```
+
 5. You are now all set
 
 ## Feedback

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,12 @@ inputs:
   skip_step:
     required: false
     description: 'which step to skip, either "install" or "build"'
+  base_size_path:
+    required: false
+    description: 'path to base branch size file, when set used directly'
+  head_size_path:
+    required: false
+    description: 'path to base branch size file, when set used directly'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -2005,6 +2005,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+const fs_1 = __webpack_require__(747);
 const core_1 = __webpack_require__(470);
 const github_1 = __webpack_require__(469);
 // @ts-ignore
@@ -2019,7 +2020,7 @@ function fetchPreviousComment(octokit, repo, pr) {
         const commentList = yield octokit.paginate("GET /repos/:owner/:repo/issues/:issue_number/comments", Object.assign(Object.assign({}, repo), { 
             // eslint-disable-next-line camelcase
             issue_number: pr.number }));
-        const sizeLimitComment = commentList.find(comment => comment.body.startsWith(SIZE_LIMIT_HEADING));
+        const sizeLimitComment = commentList.find((comment) => comment.body.startsWith(SIZE_LIMIT_HEADING));
         return !sizeLimitComment ? null : sizeLimitComment;
     });
 }
@@ -2034,13 +2035,33 @@ function run() {
             const token = core_1.getInput("github_token");
             const skipStep = core_1.getInput("skip_step");
             const buildScript = core_1.getInput("build_script");
+            const baseSizePath = core_1.getInput("base_size_path");
+            const headSizePath = core_1.getInput("head_size_path");
             const octokit = new github_1.GitHub(token);
             const term = new Term_1.default();
             const limit = new SizeLimit_1.default();
-            const { status, output } = yield term.execSizeLimit(null, skipStep, buildScript);
-            const { output: baseOutput } = yield term.execSizeLimit(pr.base.ref, null, buildScript);
+            let output;
+            let status;
+            console.log("paths", baseSizePath, headSizePath);
+            if (headSizePath) {
+                output = yield fs_1.promises.readFile(headSizePath, "utf8");
+            }
+            else {
+                const sizeLimit = yield term.execSizeLimit(null, skipStep, buildScript);
+                output = sizeLimit.output;
+                status = sizeLimit.status;
+            }
+            let baseOutput;
+            if (baseSizePath) {
+                baseOutput = yield fs_1.promises.readFile(headSizePath, "utf8");
+            }
+            else {
+                const sizeLimit = yield term.execSizeLimit(pr.base.ref, null, buildScript);
+                baseOutput = sizeLimit.output;
+            }
             let base;
             let current;
+            console.log("outputs", output.length, baseOutput.length);
             try {
                 base = limit.parseResults(baseOutput);
                 current = limit.parseResults(output);
@@ -2051,7 +2072,7 @@ function run() {
             }
             const body = [
                 SIZE_LIMIT_HEADING,
-                markdown_table_1.default(limit.formatResults(base, current))
+                markdown_table_1.default(limit.formatResults(base, current)),
             ].join("\r\n");
             const sizeLimitComment = yield fetchPreviousComment(octokit, repo, pr);
             if (!sizeLimitComment) {
@@ -2675,7 +2696,7 @@ exports.getUserAgent = getUserAgent;
 /***/ 215:
 /***/ (function(module) {
 
-module.exports = {"_args":[["@octokit/rest@16.43.1","/Users/andres.alvarez/Projects/size-limit-action"]],"_from":"@octokit/rest@16.43.1","_id":"@octokit/rest@16.43.1","_inBundle":false,"_integrity":"sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==","_location":"/@octokit/rest","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"@octokit/rest@16.43.1","name":"@octokit/rest","escapedName":"@octokit%2frest","scope":"@octokit","rawSpec":"16.43.1","saveSpec":null,"fetchSpec":"16.43.1"},"_requiredBy":["/@actions/github"],"_resolved":"https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz","_spec":"16.43.1","_where":"/Users/andres.alvarez/Projects/size-limit-action","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/rest.js/issues"},"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}],"contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"dependencies":{"@octokit/auth-token":"^2.4.0","@octokit/plugin-paginate-rest":"^1.1.1","@octokit/plugin-request-log":"^1.0.0","@octokit/plugin-rest-endpoint-methods":"2.4.0","@octokit/request":"^5.2.0","@octokit/request-error":"^1.0.2","atob-lite":"^2.0.0","before-after-hook":"^2.0.0","btoa-lite":"^1.0.0","deprecation":"^2.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","once":"^1.4.0","universal-user-agent":"^4.0.0"},"description":"GitHub REST API client for Node.js","devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/auth":"^1.1.1","@octokit/fixtures-server":"^5.0.6","@octokit/graphql":"^4.2.0","@types/node":"^13.1.0","bundlesize":"^0.18.0","chai":"^4.1.2","compression-webpack-plugin":"^3.1.0","cypress":"^3.0.0","glob":"^7.1.2","http-proxy-agent":"^4.0.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","lolex":"^5.1.2","mkdirp":"^1.0.0","mocha":"^7.0.1","mustache":"^4.0.0","nock":"^11.3.3","npm-run-all":"^4.1.2","nyc":"^15.0.0","prettier":"^1.14.2","proxy":"^1.0.0","semantic-release":"^17.0.0","sinon":"^8.0.0","sinon-chai":"^3.0.0","sort-keys":"^4.0.0","string-to-arraybuffer":"^1.0.0","string-to-jsdoc-comment":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"files":["index.js","index.d.ts","lib","plugins"],"homepage":"https://github.com/octokit/rest.js#readme","keywords":["octokit","github","rest","api-client"],"license":"MIT","name":"@octokit/rest","nyc":{"ignore":["test"]},"publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/rest.js.git"},"scripts":{"build":"npm-run-all build:*","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","build:ts":"npm run -s update-endpoints:typescript","coverage":"nyc report --reporter=html && open coverage/index.html","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","lint":"prettier --check '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","lint:fix":"prettier --write '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","prebuild:browser":"mkdirp dist/","pretest":"npm run -s lint","prevalidate:ts":"npm run -s build:ts","start-fixtures-server":"octokit-fixtures-server","test":"nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"","test:browser":"cypress run --browser chrome","update-endpoints":"npm-run-all update-endpoints:*","update-endpoints:fetch-json":"node scripts/update-endpoints/fetch-json","update-endpoints:typescript":"node scripts/update-endpoints/typescript","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts"},"types":"index.d.ts","version":"16.43.1"};
+module.exports = {"_args":[["@octokit/rest@16.43.1","/Users/klemensas/vinted/size-limit-action"]],"_from":"@octokit/rest@16.43.1","_id":"@octokit/rest@16.43.1","_inBundle":false,"_integrity":"sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==","_location":"/@octokit/rest","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"@octokit/rest@16.43.1","name":"@octokit/rest","escapedName":"@octokit%2frest","scope":"@octokit","rawSpec":"16.43.1","saveSpec":null,"fetchSpec":"16.43.1"},"_requiredBy":["/@actions/github"],"_resolved":"https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz","_spec":"16.43.1","_where":"/Users/klemensas/vinted/size-limit-action","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/rest.js/issues"},"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}],"contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"dependencies":{"@octokit/auth-token":"^2.4.0","@octokit/plugin-paginate-rest":"^1.1.1","@octokit/plugin-request-log":"^1.0.0","@octokit/plugin-rest-endpoint-methods":"2.4.0","@octokit/request":"^5.2.0","@octokit/request-error":"^1.0.2","atob-lite":"^2.0.0","before-after-hook":"^2.0.0","btoa-lite":"^1.0.0","deprecation":"^2.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","once":"^1.4.0","universal-user-agent":"^4.0.0"},"description":"GitHub REST API client for Node.js","devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/auth":"^1.1.1","@octokit/fixtures-server":"^5.0.6","@octokit/graphql":"^4.2.0","@types/node":"^13.1.0","bundlesize":"^0.18.0","chai":"^4.1.2","compression-webpack-plugin":"^3.1.0","cypress":"^3.0.0","glob":"^7.1.2","http-proxy-agent":"^4.0.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","lolex":"^5.1.2","mkdirp":"^1.0.0","mocha":"^7.0.1","mustache":"^4.0.0","nock":"^11.3.3","npm-run-all":"^4.1.2","nyc":"^15.0.0","prettier":"^1.14.2","proxy":"^1.0.0","semantic-release":"^17.0.0","sinon":"^8.0.0","sinon-chai":"^3.0.0","sort-keys":"^4.0.0","string-to-arraybuffer":"^1.0.0","string-to-jsdoc-comment":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"files":["index.js","index.d.ts","lib","plugins"],"homepage":"https://github.com/octokit/rest.js#readme","keywords":["octokit","github","rest","api-client"],"license":"MIT","name":"@octokit/rest","nyc":{"ignore":["test"]},"publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/rest.js.git"},"scripts":{"build":"npm-run-all build:*","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","build:ts":"npm run -s update-endpoints:typescript","coverage":"nyc report --reporter=html && open coverage/index.html","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","lint":"prettier --check '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","lint:fix":"prettier --write '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","prebuild:browser":"mkdirp dist/","pretest":"npm run -s lint","prevalidate:ts":"npm run -s build:ts","start-fixtures-server":"octokit-fixtures-server","test":"nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"","test:browser":"cypress run --browser chrome","update-endpoints":"npm-run-all update-endpoints:*","update-endpoints:fetch-json":"node scripts/update-endpoints/fetch-json","update-endpoints:typescript":"node scripts/update-endpoints/typescript","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts"},"types":"index.d.ts","version":"16.43.1"};
 
 /***/ }),
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2082,7 +2082,8 @@ function run() {
                     console.log("Error updating comment. This can happen for PR's originating from a fork without write permissions.");
                 }
             }
-            if (status > 0) {
+            const withinLimit = Object.values(current).every(({ passed }) => passed !== null && passed !== void 0 ? passed : true);
+            if (status > 0 || !withinLimit) {
                 core_1.setFailed("Size limit has been exceeded.");
             }
         }
@@ -9313,7 +9314,7 @@ class SizeLimit {
                     total: loading + running
                 };
             }
-            return Object.assign(Object.assign({}, current), { [result.name]: Object.assign({ name: result.name, size: +result.size }, time) });
+            return Object.assign(Object.assign({}, current), { [result.name]: Object.assign({ name: result.name, size: +result.size, passed: result.passed }, time) });
         }, {});
     }
     formatResults(base, current) {

--- a/src/SizeLimit.spec.ts
+++ b/src/SizeLimit.spec.ts
@@ -16,6 +16,7 @@ describe("SizeLimit", () => {
     expect(limit.parseResults(output)).toEqual({
       "dist/index.js": {
         name: "dist/index.js",
+        passed: true,
         loading: 2.1658984375,
         running: 0.10210999999999999,
         size: 110894,
@@ -37,6 +38,7 @@ describe("SizeLimit", () => {
     expect(limit.parseResults(output)).toEqual({
       "dist/index.js": {
         name: "dist/index.js",
+        passed: true,
         size: 110894
       }
     });

--- a/src/SizeLimit.ts
+++ b/src/SizeLimit.ts
@@ -4,6 +4,7 @@ import bytes from "bytes";
 interface IResult {
   name: string;
   size: number;
+  passed?: boolean;
   running?: number;
   loading?: number;
   total?: number;
@@ -124,6 +125,7 @@ class SizeLimit {
           [result.name]: {
             name: result.name,
             size: +result.size,
+            passed: result.passed,
             ...time
           }
         };

--- a/src/Term.ts
+++ b/src/Term.ts
@@ -1,15 +1,35 @@
+import { promises as fs } from "fs";
 import { exec } from "@actions/exec";
 import hasYarn from "has-yarn";
 
 const INSTALL_STEP = "install";
 const BUILD_STEP = "build";
 
+interface ISizeLimitParams {
+  branch?: string;
+  skipStep?: string;
+  buildScript?: string;
+}
 class Term {
-  async execSizeLimit(
-    branch?: string,
-    skipStep?: string,
-    buildScript?: string
-  ): Promise<{ status: number; output: string }> {
+  async getSizeLimit(
+    execParams: ISizeLimitParams,
+    filePath?: string
+  ): Promise<{ status?: number; output: string }> {
+    return filePath
+      ? this.readSizeLimitFile(filePath)
+      : this.execSizeLimit(execParams);
+  }
+
+  async readSizeLimitFile(filePath: string): Promise<{ output: string }> {
+    const output = await fs.readFile(filePath, "utf8");
+    return { output };
+  }
+
+  async execSizeLimit({
+    branch,
+    skipStep,
+    buildScript
+  }: ISizeLimitParams): Promise<{ status: number; output: string }> {
     const manager = hasYarn() ? "yarn" : "npm";
     let output = "";
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -113,7 +113,10 @@ async function run() {
       }
     }
 
-    if (status > 0) {
+    const withinLimit = Object.values(current).every(
+      ({ passed }) => passed ?? true
+    );
+    if (status > 0 || !withinLimit) {
       setFailed("Size limit has been exceeded.");
     }
   } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,11 +20,11 @@ async function fetchPreviousComment(
     {
       ...repo,
       // eslint-disable-next-line camelcase
-      issue_number: pr.number
+      issue_number: pr.number,
     }
   );
 
-  const sizeLimitComment = commentList.find(comment =>
+  const sizeLimitComment = commentList.find((comment) =>
     comment.body.startsWith(SIZE_LIMIT_HEADING)
   );
   return !sizeLimitComment ? null : sizeLimitComment;
@@ -53,6 +53,8 @@ async function run() {
     let output: string;
     let status;
 
+    console.log("paths", baseSizePath, headSizePath);
+
     if (headSizePath) {
       output = await fs.readFile(headSizePath, "utf8");
     } else {
@@ -76,6 +78,8 @@ async function run() {
     let base;
     let current;
 
+    console.log("outputs", output.length, baseOutput.length);
+
     try {
       base = limit.parseResults(baseOutput);
       current = limit.parseResults(output);
@@ -88,7 +92,7 @@ async function run() {
 
     const body = [
       SIZE_LIMIT_HEADING,
-      table(limit.formatResults(base, current))
+      table(limit.formatResults(base, current)),
     ].join("\r\n");
 
     const sizeLimitComment = await fetchPreviousComment(octokit, repo, pr);
@@ -99,7 +103,7 @@ async function run() {
           ...repo,
           // eslint-disable-next-line camelcase
           issue_number: pr.number,
-          body
+          body,
         });
       } catch (error) {
         console.log(
@@ -112,7 +116,7 @@ async function run() {
           ...repo,
           // eslint-disable-next-line camelcase
           comment_id: sizeLimitComment.id,
-          body
+          body,
         });
       } catch (error) {
         console.log(


### PR DESCRIPTION
I have a case where I need additional auth to install dependencies and my size-limit configuration is not in the root path.

So to support such a case I've added additional inputs for `base_size_path` and `head_size_path`. These paths should lead to an already generated size limit report.
Providing a path tries to load the file directly and skips the install, build, exec steps.

To use this you should do your setup in the action and just pass the paths, my usage looks something like this:
```yml
      ...
      - name: authenticate
        uses: webfactory/ssh-agent@v0.2.0
        with:
          ssh-private-key: ${{ secrets.PRIVATE_KEY}}
      - uses: actions/checkout@v2
        with:
          path: head
      - uses: actions/checkout@v2
        with:
          ref: ${{ github.base_ref }}
          path: base
      - name: head setup
        working-directory: ./head/client
        run: yarn install && yarn build && yarn --silent size --json > size.json
      - name: base setup
        working-directory: ./base/client
        run: yarn install && yarn build && yarn --silent size --json > size.json
      - name: size limit
        uses: vinted/size-limit-action@master
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          base_size_path: ./base/client/size.json
          head_size_path: ./head/client/size.json
```