### PR TITLE
feature: support customize manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,14 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
-You can optionally specify a custom npm script to run instead of the default `build` adding a `build_script` option to the yml workflow shown above. Additionally, providing a `skip_step` option will tell the action to skip either the `install` or `build` phase.
+You can optionally specify a custom npm script to run instead of the default `build` adding a `build_script` option to the yml workflow shown above. Additionally, providing a `skip_step` option will tell the action to skip either the `install` or `build` phase. You can also specify the package manager by configuring the `manager` option.
 
 ```yaml
 with:
   github_token: ${{ secrets.GITHUB_TOKEN }}
   build_script: custom-build
   skip_step: install
+  manager: npm
 ```
 
 5. You are now all set

--- a/src/Term.ts
+++ b/src/Term.ts
@@ -8,9 +8,10 @@ class Term {
   async execSizeLimit(
     branch?: string,
     skipStep?: string,
-    buildScript?: string
+    buildScript?: string,
+    packageManager?: string
   ): Promise<{ status: number; output: string }> {
-    const manager = hasYarn() ? "yarn" : "npm";
+    const manager = packageManager || hasYarn() ? "yarn" : "npm";
     let output = "";
 
     if (branch) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,7 @@ async function run() {
         "No PR found. Only pull_request workflows are supported."
       );
     }
-
+    const manager = getInput("manager");
     const token = getInput("github_token");
     const skipStep = getInput("skip_step");
     const buildScript = getInput("build_script");
@@ -50,12 +50,14 @@ async function run() {
     const { status, output } = await term.execSizeLimit(
       null,
       skipStep,
-      buildScript
+      buildScript,
+      manager
     );
     const { output: baseOutput } = await term.execSizeLimit(
       pr.base.ref,
       null,
-      buildScript
+      buildScript,
+      manager
     );
 
     let base;


### PR DESCRIPTION
In some case, we need customize package manager, such as using yarn workspace, I can't install package in the root directory by yarn, so I want to customize the manager be npm.

![image](https://user-images.githubusercontent.com/11213298/88907743-9593cd00-d28b-11ea-97f0-e8d48d0f1ee4.png)

so I think it should support customize package manager.

