### PR TITLE
feat: support "directory" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,23 +72,12 @@ It's only convenient if all your stuff is in a subdirectory of your git reposito
 
 For instance, if `package.json` is in the subfolder `client/`:
 
-```diff
-name: Compressed Size
-
-on: [pull_request]
-
-jobs:
-  build:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - uses: Arhia/action-check-compressed-size@v0.7
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        build-script: "ci"
-+        directory: client/
+```yaml
+with:
+  github_token: ${{ secrets.GITHUB_TOKEN }}
+  build_script: custom-build
+  skip_step: install
+  directory: client/
 ```
 
 ## Feedback

--- a/README.md
+++ b/README.md
@@ -65,6 +65,32 @@ with:
 
 5. You are now all set
 
+### Customizing working directory
+    
+`directory` option allow to run all the tasks in a subfolder.
+It's only convenient if all your stuff is in a subdirectory of your git repository.
+
+For instance, if `package.json` is in the subfolder `client/`:
+
+```diff
+name: Compressed Size
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: Arhia/action-check-compressed-size@v0.7
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        build-script: "ci"
++        directory: client/
+```
+
 ## Feedback
 
 Pull requests, feature ideas and bug reports are very welcome. We highly appreciate any feedback.

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   skip_step:
     required: false
     description: 'which step to skip, either "install" or "build"'
+  directory:
+    required: false
+    description: "a custom subdirectory"
   windows_verbatim_arguments:
     required: false
     description: "exec `size-limit` with the option `windowsVerbatimArguments`"

--- a/src/Term.ts
+++ b/src/Term.ts
@@ -9,7 +9,8 @@ class Term {
     branch?: string,
     skipStep?: string,
     buildScript?: string,
-    windowsVerbatimArguments?: boolean
+    windowsVerbatimArguments?: boolean,
+    directory?: string
   ): Promise<{ status: number; output: string }> {
     const manager = hasYarn() ? "yarn" : "npm";
     let output = "";
@@ -25,12 +26,16 @@ class Term {
     }
 
     if (skipStep !== INSTALL_STEP && skipStep !== BUILD_STEP) {
-      await exec(`${manager} install`);
+      await exec(`${manager} install`, [], {
+        cwd: directory
+      });
     }
 
     if (skipStep !== BUILD_STEP) {
       const script = buildScript || "build";
-      await exec(`${manager} run ${script}`);
+      await exec(`${manager} run ${script}`, [], {
+        cwd: directory
+      });
     }
 
     const status = await exec("npx size-limit --json", [], {
@@ -40,7 +45,8 @@ class Term {
         stdout: (data: Buffer) => {
           output += data.toString();
         }
-      }
+      },
+      cwd: directory
     });
 
     return {

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,6 +43,7 @@ async function run() {
     const token = getInput("github_token");
     const skipStep = getInput("skip_step");
     const buildScript = getInput("build_script");
+    const directory = getInput("directory") || process.cwd();
     const windowsVerbatimArguments =
       getInput("windows_verbatim_arguments") === "true" ? true : false;
     const octokit = new GitHub(token);
@@ -53,13 +54,15 @@ async function run() {
       null,
       skipStep,
       buildScript,
-      windowsVerbatimArguments
+      windowsVerbatimArguments,
+      directory
     );
     const { output: baseOutput } = await term.execSizeLimit(
       pr.base.ref,
       null,
       buildScript,
-      windowsVerbatimArguments
+      windowsVerbatimArguments,
+      directory
     );
 
     let base;


### PR DESCRIPTION
This PR aims to support running action in subdirectory.

This `directory` option helps us to use this action in a repository that has not package.json in root directory.

fix #38 