### PR TITLE
fix: added directory to yarn check

### DIFF
--- a/src/Term.ts
+++ b/src/Term.ts
@@ -12,7 +12,7 @@ class Term {
     windowsVerbatimArguments?: boolean,
     directory?: string
   ): Promise<{ status: number; output: string }> {
-    const manager = hasYarn() ? "yarn" : "npm";
+    const manager = hasYarn(directory) ? "yarn" : "npm";
     let output = "";
 
     if (branch) {


### PR DESCRIPTION
When I used the directory param I noticed that `npm` was used instead of `yarn` even as I had setup my project with it.

As the `hasYarn` function allows to pass in a path as argument I used this to fix the problem.