### PR TITLE
Add clean_script option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,18 @@ with:
   skip_step: install
 ```
 
+Add `clean_script` option to specify npm script to run after size-limit results are collected. This is useful to clean up leftover assets.
+
+```yaml
+with:
+  github_token: ${{ secrets.GITHUB_TOKEN }}
+  clean_script: cleanup
+```
+
 5. You are now all set
 
 ### Customizing working directory
-    
+
 `directory` option allow to run all the tasks in a subfolder.
 It's only convenient if all your stuff is in a subdirectory of your git repository.
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   build_script:
     required: false
     description: 'a custom npm script to build'
+  clean_script:
+    required: false
+    description: 'a npm script to clean up build directory'
   skip_step:
     required: false
     description: 'which step to skip, either "install" or "build"'

--- a/src/Term.ts
+++ b/src/Term.ts
@@ -9,6 +9,7 @@ class Term {
     branch?: string,
     skipStep?: string,
     buildScript?: string,
+    cleanScript?: string,
     windowsVerbatimArguments?: boolean,
     directory?: string
   ): Promise<{ status: number; output: string }> {
@@ -48,6 +49,12 @@ class Term {
       },
       cwd: directory
     });
+
+    if (cleanScript) {
+      await exec(`${manager} run ${cleanScript}`, [], {
+        cwd: directory
+      });
+    }
 
     return {
       status,

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,7 @@ async function run() {
     const token = getInput("github_token");
     const skipStep = getInput("skip_step");
     const buildScript = getInput("build_script");
+    const cleanScript = getInput("clean_script");
     const directory = getInput("directory") || process.cwd();
     const windowsVerbatimArguments =
       getInput("windows_verbatim_arguments") === "true" ? true : false;
@@ -53,6 +54,7 @@ async function run() {
       null,
       skipStep,
       buildScript,
+      cleanScript,
       windowsVerbatimArguments,
       directory
     );
@@ -60,6 +62,7 @@ async function run() {
       pr.base.ref,
       null,
       buildScript,
+      cleanScript,
       windowsVerbatimArguments,
       directory
     );


### PR DESCRIPTION
Hey, great action! It works beautifully!

The only thing I thought would be nice to have is an option to specify clean up script. Such script is useful to remove assets between builds, especially if assets are fingerprinted. I found closed issue about this problem https://github.com/andresz1/size-limit-action/issues/31#issuecomment-680251881, but I can't find exactly what was added to readme about that case.