### PR TITLE
feat: replace `skip_step:` with `skip_build` and `skip_install`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,7 @@ inputs:
     description: 'a github access token'
   build_script:
     required: false
+    default: "build"
     description: 'a custom npm script to build'
   clean_script:
     required: false

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     description: "a custom subdirectory"
   windows_verbatim_arguments:
     required: false
-    default: true
+    default: "true"
     description: "exec `size-limit` with the option `windowsVerbatimArguments`"
   script:
     required: false

--- a/action.yml
+++ b/action.yml
@@ -15,9 +15,14 @@ inputs:
   clean_script:
     required: false
     description: 'a npm script to clean up build directory'
-  skip_step:
+  skip_install:
     required: false
-    description: 'which step to skip, either "install" or "build"'
+    default: 'false'
+    description: 'Whether to skip `install` step'
+  skip_build:
+    required: false
+    default: 'false'
+    description: 'Whether to skip `build` step'
   directory:
     required: false
     description: "a custom subdirectory"

--- a/action.yml
+++ b/action.yml
@@ -22,8 +22,8 @@ inputs:
     description: "a custom subdirectory"
   windows_verbatim_arguments:
     required: false
-    description: "exec `size-limit` with the option `windowsVerbatimArguments`"
     default: true
+    description: "exec `size-limit` with the option `windowsVerbatimArguments`"
   script:
     required: false
     default: "npx size-limit --json"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "size-limit-action",
       "version": "1.7.0",
       "license": "ISC",
       "dependencies": {

--- a/src/Term.ts
+++ b/src/Term.ts
@@ -8,11 +8,11 @@ const BUILD_STEP = "build";
 class Term {
   async execSizeLimit(
     script: string,
+    windowsVerbatimArguments: boolean,
     branch?: string,
     skipStep?: string,
     buildScript?: string,
     cleanScript?: string,
-    windowsVerbatimArguments?: boolean,
     directory?: string
   ): Promise<{ status: number; output: string }> {
     const manager = hasYarn(directory)

--- a/src/Term.ts
+++ b/src/Term.ts
@@ -7,13 +7,13 @@ const BUILD_STEP = "build";
 
 class Term {
   async execSizeLimit(
+    script: string,
     branch?: string,
     skipStep?: string,
     buildScript?: string,
     cleanScript?: string,
     windowsVerbatimArguments?: boolean,
-    directory?: string,
-    script?: string
+    directory?: string
   ): Promise<{ status: number; output: string }> {
     const manager = hasYarn(directory)
       ? "yarn"

--- a/src/Term.ts
+++ b/src/Term.ts
@@ -4,14 +4,16 @@ import hasPNPM from "has-pnpm";
 
 const INSTALL_STEP = "install";
 const BUILD_STEP = "build";
+const ALL_STEPS = "all";
 
 class Term {
   async execSizeLimit(
     script: string,
     buildScript: string,
+    skipInstall: boolean,
+    skipBuild: boolean,
     windowsVerbatimArguments: boolean,
     branch?: string,
-    skipStep?: string,
     cleanScript?: string,
     directory?: string
   ): Promise<{ status: number; output: string }> {
@@ -32,13 +34,13 @@ class Term {
       await exec(`git checkout -f ${branch}`);
     }
 
-    if (skipStep !== INSTALL_STEP && skipStep !== BUILD_STEP) {
+    if (!skipInstall) {
       await exec(`${manager} install`, [], {
         cwd: directory
       });
     }
 
-    if (skipStep !== BUILD_STEP) {
+    if (!skipBuild) {
       await exec(`${manager} run ${buildScript}`, [], {
         cwd: directory
       });

--- a/src/Term.ts
+++ b/src/Term.ts
@@ -8,10 +8,10 @@ const BUILD_STEP = "build";
 class Term {
   async execSizeLimit(
     script: string,
+    buildScript: string,
     windowsVerbatimArguments: boolean,
     branch?: string,
     skipStep?: string,
-    buildScript?: string,
     cleanScript?: string,
     directory?: string
   ): Promise<{ status: number; output: string }> {
@@ -39,8 +39,7 @@ class Term {
     }
 
     if (skipStep !== BUILD_STEP) {
-      const script = buildScript || "build";
-      await exec(`${manager} run ${script}`, [], {
+      await exec(`${manager} run ${buildScript}`, [], {
         cwd: directory
       });
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,22 +52,22 @@ async function run() {
     const limit = new SizeLimit();
 
     const { status, output } = await term.execSizeLimit(
+      script,
       null,
       skipStep,
       buildScript,
       cleanScript,
       windowsVerbatimArguments,
-      directory,
-      script
+      directory
     );
     const { output: baseOutput } = await term.execSizeLimit(
+      script,
       pr.base.ref,
       null,
       buildScript,
       cleanScript,
       windowsVerbatimArguments,
-      directory,
-      script
+      directory
     );
 
     let base;

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,20 +53,20 @@ async function run() {
 
     const { status, output } = await term.execSizeLimit(
       script,
+      windowsVerbatimArguments,
       null,
       skipStep,
       buildScript,
       cleanScript,
-      windowsVerbatimArguments,
       directory
     );
     const { output: baseOutput } = await term.execSizeLimit(
       script,
+      windowsVerbatimArguments,
       pr.base.ref,
       null,
       buildScript,
       cleanScript,
-      windowsVerbatimArguments,
       directory
     );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,19 +53,19 @@ async function run() {
 
     const { status, output } = await term.execSizeLimit(
       script,
+      buildScript,
       windowsVerbatimArguments,
       null,
       skipStep,
-      buildScript,
       cleanScript,
       directory
     );
     const { output: baseOutput } = await term.execSizeLimit(
       script,
+      buildScript,
       windowsVerbatimArguments,
       pr.base.ref,
       null,
-      buildScript,
       cleanScript,
       directory
     );

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,13 +40,14 @@ async function run() {
     }
 
     const token = getInput("github_token");
-    const skipStep = getInput("skip_step");
-    const buildScript = getInput("build_script");
-    const cleanScript = getInput("clean_script");
     const script = getInput("script");
+    const buildScript = getInput("build_script");
+    const skipInstall = getInput("skip_install") === "true";
+    const skipBuild = getInput("skip_build") === "true";
+    const cleanScript = getInput("clean_script");
     const directory = getInput("directory") || process.cwd();
     const windowsVerbatimArguments =
-      getInput("windows_verbatim_arguments") === "true" ? true : false;
+      getInput("windows_verbatim_arguments") === "true";
     const octokit = new GitHub(token);
     const term = new Term();
     const limit = new SizeLimit();
@@ -54,18 +55,20 @@ async function run() {
     const { status, output } = await term.execSizeLimit(
       script,
       buildScript,
+      skipInstall,
+      skipBuild,
       windowsVerbatimArguments,
       null,
-      skipStep,
       cleanScript,
       directory
     );
     const { output: baseOutput } = await term.execSizeLimit(
       script,
       buildScript,
+      skipInstall,
+      skipBuild,
       windowsVerbatimArguments,
       pr.base.ref,
-      null,
       cleanScript,
       directory
     );


### PR DESCRIPTION
When skipping `build` it was also skipping `install`.
However, `install` might be needed to install an `size-limit` preset.

One may want to skip `build` (e.g. if the `size` scripts builds first
as per size-limit's doc) without skipping `install`.

Adding the `all` option gives more flexibility to the user.

Fixes #84