### PR TITLE
feat: add create_comment_for_each_run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ with:
   package_manager: yarn
 ```
 
+### Creating PR comment for each run
+
+By default, if the action is run multiple times, it will update the same comment. If you want to create a new comment for each run, you can set the `create_comment_for_each_run` option to `true`.
+
+```yaml
+with:
+  github_token: ${{ secrets.GITHUB_TOKEN }}
+  create_comment_for_each_run: true
+```
+
 ## Feedback
 
 Pull requests, feature ideas and bug reports are very welcome. We highly appreciate any feedback.

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
   package_manager:
     required: false
     description: "The package manager used to run the build and install commands. If not provided, the manager will be auto detected. Example values: `yarn`, `npm`, `pnpm`."
+  create_comment_for_each_run:
+    required: false
+    description: "If true, create a new comment for each run. If false (default), the action will update the previous comment."
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -3845,6 +3845,7 @@ function run() {
             const packageManager = core_1.getInput("package_manager");
             const directory = core_1.getInput("directory") || process.cwd();
             const windowsVerbatimArguments = core_1.getInput("windows_verbatim_arguments") === "true" ? true : false;
+            const createCommentForEachRun = core_1.getInput("create_comment_for_each_run") === "true" ? true : false;
             const octokit = new github_1.GitHub(token);
             const term = new Term_1.default();
             const limit = new SizeLimit_1.default();
@@ -3865,7 +3866,7 @@ function run() {
                 markdown_table_1.default(limit.formatResults(base, current))
             ].join("\r\n");
             const sizeLimitComment = yield fetchPreviousComment(octokit, repo, pr);
-            if (!sizeLimitComment) {
+            if (!sizeLimitComment || createCommentForEachRun) {
                 try {
                     yield octokit.issues.createComment(Object.assign(Object.assign({}, repo), { 
                         // eslint-disable-next-line camelcase

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,6 +48,8 @@ async function run() {
     const directory = getInput("directory") || process.cwd();
     const windowsVerbatimArguments =
       getInput("windows_verbatim_arguments") === "true" ? true : false;
+    const createCommentForEachRun =
+      getInput("create_comment_for_each_run") === "true" ? true : false;
     const octokit = new GitHub(token);
     const term = new Term();
     const limit = new SizeLimit();
@@ -93,7 +95,7 @@ async function run() {
 
     const sizeLimitComment = await fetchPreviousComment(octokit, repo, pr);
 
-    if (!sizeLimitComment) {
+    if (!sizeLimitComment || createCommentForEachRun) {
       try {
         await octokit.issues.createComment({
           ...repo,


### PR DESCRIPTION
This pull request adds `create_comment_for_each_run` option.

If this option is set to `true`, the action can create multiple comments to one PR.

It is useful if multiple scripts are built in one repository, like a monorepo.

related issues: #67 