### PR TITLE
Add `write` permission to the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ on:
   pull_request:
     branches:
       - master
+permissions:
+  pull-requests: write
 jobs:
   size:
     runs-on: ubuntu-latest


### PR DESCRIPTION
After run a workflow, the action couldn't create a comment on the PR remaining a log with below message

```bash
Error creating comment. This can happen for PR's originating from a fork without write permissions.
```

It can be fixed by follow https://github.com/andresz1/size-limit-action/issues/104#issuecomment-1534099984


```yaml
permissions:
  pull-requests: write
```

The documentation has not yet been updated to reflect this, which is confusing for many new users. 
Hopefully they will be updated soon.