### PR TITLE
Update `node12` to `node20`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,5 +32,5 @@ inputs:
     required: false
     description: "The package manager used to run the build and install commands. If not provided, the manager will be auto detected. Example values: `yarn`, `npm`, `pnpm`."
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -32,5 +32,5 @@ inputs:
     required: false
     description: "The package manager used to run the build and install commands. If not provided, the manager will be auto detected. Example values: `yarn`, `npm`, `pnpm`."
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Github action will run on Node16 by befault soon : https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

There is warning when action is running :
<img width="1024" alt="image" src="https://github.com/andresz1/size-limit-action/assets/35960493/d54b9ddf-2c15-4f6f-afc1-63498a68d089">

Fix this issue : https://github.com/andresz1/size-limit-action/issues/93