### PR TITLE
Fix build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "size-limit-action",
       "version": "1.7.0",
       "license": "ISC",
       "dependencies": {
@@ -22,7 +23,7 @@
         "@types/jest": "^24.0.23",
         "@types/node": "^12.7.12",
         "@typescript-eslint/parser": "^2.8.0",
-        "@zeit/ncc": "^0.22.1",
+        "@vercel/ncc": "^0.38.1",
         "eslint": "^5.16.0",
         "eslint-plugin-github": "^2.0.0",
         "eslint-plugin-jest": "^22.21.0",
@@ -1858,11 +1859,10 @@
         }
       }
     },
-    "node_modules/@zeit/ncc": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.22.3.tgz",
-      "integrity": "sha512-jnCLpLXWuw/PAiJiVbLjA8WBC0IJQbFeUwF4I9M+23MvIxTxk5pD4Q8byQBSPmHQjz5aBoA7AKAElQxMpjrCLQ==",
-      "deprecated": "@zeit/ncc is no longer maintained. Please use @vercel/ncc instead.",
+    "node_modules/@vercel/ncc": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
+      "integrity": "sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
@@ -13254,10 +13254,10 @@
         "tsutils": "^3.17.1"
       }
     },
-    "@zeit/ncc": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.22.3.tgz",
-      "integrity": "sha512-jnCLpLXWuw/PAiJiVbLjA8WBC0IJQbFeUwF4I9M+23MvIxTxk5pD4Q8byQBSPmHQjz5aBoA7AKAElQxMpjrCLQ==",
+    "@vercel/ncc": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
+      "integrity": "sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==",
       "dev": true
     },
     "abab": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/jest": "^24.0.23",
     "@types/node": "^12.7.12",
     "@typescript-eslint/parser": "^2.8.0",
-    "@zeit/ncc": "^0.22.1",
+    "@vercel/ncc": "^0.38.1",
     "eslint": "^5.16.0",
     "eslint-plugin-github": "^2.0.0",
     "eslint-plugin-jest": "^22.21.0",

--- a/src/Term.ts
+++ b/src/Term.ts
@@ -2,9 +2,9 @@ import { exec } from "@actions/exec";
 import hasYarn from "has-yarn";
 import hasPNPM from "has-pnpm";
 
-import process from 'node:process';
-import path from 'node:path';
-import fs from 'node:fs';
+import process from 'process';
+import path from 'path';
+import fs from 'fs';
 
 function hasBun(cwd = process.cwd()) {
 	return fs.existsSync(path.resolve(cwd, 'bun.lockb'));


### PR DESCRIPTION
The `@zeit/ncc` dependency is now deprecated. And the author say use `@vercel/ncc` instead.

See : https://www.npmjs.com/package/@zeit/ncc