### PR TITLE
fix: allow parsing of custom script outputs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30762,7 +30762,9 @@ class SizeLimit {
         ];
     }
     parseResults(output) {
-        const results = JSON.parse(output);
+        const begin = output.indexOf("[");
+        const end = output.lastIndexOf("]");
+        const results = JSON.parse(output.slice(begin, end + 1));
         return results.reduce((current, result) => {
             let time = {};
             if (result.loading !== undefined && result.running !== undefined) {

--- a/src/SizeLimit.ts
+++ b/src/SizeLimit.ts
@@ -102,7 +102,9 @@ class SizeLimit {
   }
 
   parseResults(output: string): { [name: string]: IResult } {
-    const results = JSON.parse(output);
+    const begin = output.indexOf("[");
+    const end = output.lastIndexOf("]");
+    const results = JSON.parse(output.slice(begin, end + 1));
 
     return results.reduce(
       (current: { [name: string]: IResult }, result: any) => {


### PR DESCRIPTION
## Description

```
with:
  script: "npm run my-script"
```

is resulting in an output that starts with some preamble before the JSON array is printed. 

This preamble is resulting in the JSON.parse failing.

**Example**

```
> package@0.0.1 size /path/to/repo
> size-limit "--json"

[
  {
    "name": "bundle-one",
    "passed": true,
    "size": 9319,
    "sizeLimit": 10000,
    "running": 0.23261666666666667,
    "loading": 0.18201171875
  },
  {
    "name": "bundle-two",
    "passed": true,
    "size": 11037,
    "sizeLimit": 12000,
    "running": 0.26038333333333336,
    "loading": 0.21556640625
  },
  {
    "name": "bundle-three",
    "passed": true,
    "size": 29620,
    "sizeLimit": 35000,
    "running": 0.25188333333333335,
    "loading": 0.578515625
  }
]
```


## Fix

By finding the first '[' and last ']', we ensure we only try parse the JSON array part of the string