### PR TITLE
fix: preserve loading metric when running is missing

### DIFF
--- a/src/SizeLimit.ts
+++ b/src/SizeLimit.ts
@@ -107,17 +107,25 @@ class SizeLimit {
     return results.reduce(
       (current: { [name: string]: IResult }, result: any) => {
         let time = {};
+        let loading, running, total;
 
-        if (result.loading !== undefined && result.running !== undefined) {
-          const loading = +result.loading;
-          const running = +result.running;
-
-          time = {
-            running,
-            loading,
-            total: loading + running
-          };
+        if (result.loading !== undefined) {
+          loading = +result.loading;
         }
+
+        if (result.running !== undefined) {
+          running = +result.running;
+        }
+
+        if (loading !== undefined || running !== undefined) {
+          total = (loading || 0) + (running || 0);
+        }
+        
+        time = {
+          running,
+          loading,
+          total
+        };
 
         return {
           ...current,


### PR DESCRIPTION
Currently if running is set to false in the size-limit config, both loading and running are hidden from the report that is added to the PR as a comment. This PR fixes that